### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![NPM Version](http://img.shields.io/npm/v/altnode.feedback-delay-node.svg?style=flat-square)](https://www.npmjs.org/package/altnode.feedback-delay-node)
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](http://mohayonao.mit-license.org/)
 
+![graph](https://github.com/altnode/feedback-delay-node/wiki/images/feedback-delay-node.png)
+
 ## Installation
 
 ```
@@ -10,7 +12,7 @@ npm install -S altnode.feedback-delay-node
 ```
 
 ## API
-### AudioNode
+### FeedbackDelayNode
 - `constructor(audioContext: AudioContext, maxDelayTime = 1)`
 
 #### Instance attributes

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/altnode/feedback-delay-node/issues"
   },
   "dependencies": {
-    "altnode.audio-node": "^0.1.1"
+    "altnode.alt-audio-node": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altnode.feedback-delay-node",
   "description": "altnode.FeedbackDelayNode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Nao Yonamine <mohayonao@gmail.com>",
   "bugs": {
     "url": "https://github.com/altnode/feedback-delay-node/issues"

--- a/src/FeedbackDelayNode.js
+++ b/src/FeedbackDelayNode.js
@@ -1,7 +1,7 @@
-import AudioNode from "altnode.audio-node";
+import AltAudioNode from "altnode.alt-audio-node";
 import { DELAY, FEEDBACK } from "./symbols";
 
-export default class FeedbackDelayNode extends AudioNode {
+export default class FeedbackDelayNode extends AltAudioNode {
   constructor(audioContext, maxDelayTime = 1.0) {
     super(audioContext);
 


### PR DESCRIPTION
- use `altnode.AltAudioNode` instead of `altnode.AudioNode`
